### PR TITLE
Added missing parameter and fixed spelling errors

### DIFF
--- a/NuGetKeyVaultSignTool/Program.cs
+++ b/NuGetKeyVaultSignTool/Program.cs
@@ -33,7 +33,7 @@ namespace NuGetKeyVaultSignTool
 
                 var packagePath = signConfiguration.Argument("packagePath", "Package to sign.");
                 var outputPath = signConfiguration.Option("-o | --output", "The output file. If omitted, overwrites input.", CommandOptionType.SingleValue);
-                var force = signConfiguration.Option("-f | --force", "Overwrites a sigature if it exists.", CommandOptionType.NoValue);
+                var force = signConfiguration.Option("-f | --force", "Overwrites a signature if it exists.", CommandOptionType.NoValue);
                 var fileDigestAlgorithm = signConfiguration.Option("-fd | --file-digest", "The digest algorithm to hash the file with. Default option is sha256", CommandOptionType.SingleValue);
                 var rfc3161TimeStamp = signConfiguration.Option("-tr | --timestamp-rfc3161", "Specifies the RFC 3161 timestamp server's URL. If this option (or -t) is not specified, the signed file will not be timestamped.", CommandOptionType.SingleValue);
                 var rfc3161Digest = signConfiguration.Option("-td | --timestamp-digest", "Used with the -tr switch to request a digest algorithm used by the RFC 3161 timestamp server. Default option is sha256", CommandOptionType.SingleValue);
@@ -52,7 +52,8 @@ namespace NuGetKeyVaultSignTool
                 {
                     if (string.IsNullOrWhiteSpace(packagePath.Value))
                     {
-                        logger.LogError("Path to file(s) to sign are requried");
+                        const string V = "Path to file(s) to sign are requried";
+                        object p = logger.LogError(V);
                         return -1;
                     }
 

--- a/README.md
+++ b/README.md
@@ -8,13 +8,13 @@ This tool adds [code signatures to a NuGet package](https://docs.microsoft.com/e
 This tool is a .NET Core global tool. It can be installed with `dotnet tool install --global NuGetKeyVaultSignTool`. The tool requires the .NET Core 3.1 SDK on Windows and .NET 5.0 on other platforms.
 
 Example:
+
 ```ps1
 # Install the tool
 dotnet tool install --global NuGetKeyVaultSignTool
 
 # Alternatively, install the tool locally
 # dotnet tool install --tool-path . NuGetKeyVaultSignTool
-
 
 # Produce a package
 & dotnet pack src/MyLibrary/
@@ -46,17 +46,22 @@ FILE_PATH = the path to the .nupkg file produced by `dotnet pack` or `nuget.exe 
 Options:
 
 * `-o | --output` - The output file. If omitted, overwrites input.
-* `-f | --force` - Overwrites a sigature if it exists.
+* `-f | --force` - Overwrites a signature if it exists.
 * `-fd | --file-digest` - The digest algorithm to hash the file with.
 * `-tr | --timestamp-rfc3161` - Specifies the RFC 3161 timestamp server's URL. If this option (or -t) is not specified, the signed file will not be timestamped.
 * `-td | --timestamp-digest` - Used with the -tr switch to request a digest algorithm used by the RFC 3161 timestamp server.
 * `-st | --signature-type` - The signature type (omit for author, default. Only author is supported currently).
 * `-kvu | --azure-key-vault-url` - The URL to an Azure Key Vault.
+* `-kvt | --azure-key-vault-tenant-id` - The Tenant Id to authenticate to the Azure Key Vault..
 * `-kvi | --azure-key-vault-client-id` - The Client ID to authenticate to the Azure Key Vault.
 * `-kvs | --azure-key-vault-client-secret` - The Client Secret to authenticate to the Azure Key Vault.
 * `-kvc | --azure-key-vault-certificate` - The name of the certificate in Azure Key Vault.
 * `-kva | --azure-key-vault-accesstoken` - The Access Token to authenticate to the Azure Key Vault.
 * `-kvm | --azure-key-vault-managed-identity` - Use a Managed Identity to access Azure Key Vault.
+
+**Note** For the authentication options to Azure Key Vault, either one of the following options are required:
+
+`azure-key-vault-client-id` and `azure-key-vault-client-secret` and `azure-key-vault-tenant-id` or `azure-key-vault-accesstoken` or `azure-key-vault-managed-identity`.
 
 ## `verify`
 
@@ -65,4 +70,3 @@ Verifies that a NuGet package has been code-signed.
 Usage: `NuGetKeyVaultSignTool verify [options] <FILE_PATH>`
 
 FILE_PATH = the path to the .nupkg file produced by `dotnet pack` or `nuget.exe pack`.
-


### PR DESCRIPTION
I added in the missing `azure-key-vault-tenant-id` parameter to the options. Also added some additional clarity around the authentication options.  As a bonus, I fixed some spelling errors.  No 'code' was changed